### PR TITLE
Full text search

### DIFF
--- a/app/host/[host]/page.tsx
+++ b/app/host/[host]/page.tsx
@@ -71,7 +71,7 @@ export default async function Host({params: {host}}: {params: {host: string}}) {
           <tr>
             <th>Name</th>
             <th>URL</th>
-            <th>Rank</th>
+            <th>Reported</th>
           </tr>
         </thead>
         <tbody>
@@ -87,7 +87,7 @@ export default async function Host({params: {host}}: {params: {host: string}}) {
                   <Highlighted tokens={record.urlTokens} />
                 </Link>
               </td>
-              <td>{record.rank}</td>
+              <td>{record.count} time(s) during {record.startDate} and {record.endDate}</td>
             </tr>
           ))}
         </tbody>

--- a/app/host/[host]/page.tsx
+++ b/app/host/[host]/page.tsx
@@ -1,6 +1,8 @@
+import Link from 'next/link';
+
 import { getRequestContext } from '@cloudflare/next-on-pages';
 import { searchSimilar } from '@/lib/fts';
-import Link from 'next/link';
+import Highlighted from '@/components/Highlighted';
 
 export const runtime = 'edge';
 type Record = {
@@ -73,10 +75,18 @@ export default async function Host({params: {host}}: {params: {host: string}}) {
           </tr>
         </thead>
         <tbody>
-          {ftsHits.map((record) => (
+        {ftsHits.map((record) => (
             <tr key={record.rowid}>
-              <td><Link href={`/name/${record.name}`}>{record.name}</Link></td>
-              <td><Link href={`/host/${record.host}`}>{record.url}</Link></td>
+              <td>
+                <Link href={`/name/${record.nameTokens.join('')}`}>
+                  <Highlighted tokens={record.nameTokens} />
+                </Link>
+              </td>
+              <td>
+                <Link href={`/host/${record.host}`}>
+                  <Highlighted tokens={record.urlTokens} />
+                </Link>
+              </td>
               <td>{record.rank}</td>
             </tr>
           ))}

--- a/app/host/[host]/page.tsx
+++ b/app/host/[host]/page.tsx
@@ -1,4 +1,6 @@
 import { getRequestContext } from '@cloudflare/next-on-pages';
+import { searchSimilar } from '@/lib/fts';
+import Link from 'next/link';
 
 export const runtime = 'edge';
 type Record = {
@@ -14,41 +16,68 @@ type Record = {
 async function getRecords(host: string) {
   'use server';
   const db = getRequestContext().env.DB;
-  const { results } = await db.prepare(`
+  const directHitPromise = db.prepare(`
     SELECT *
     FROM ScamSiteRecord
     WHERE lower(host) = lower(?)
     ORDER BY endDate DESC
-  `).bind(host).all<Record>();
+  `).bind(host).all<Record>().then(({results}) => results);
 
-  return results;
+  return Promise.all([directHitPromise, searchSimilar(host)]);
 }
 
 export default async function Host({params: {host}}: {params: {host: string}}) {
-  const records = await getRecords(host);
+  const [directHits, ftsHits] = await getRecords(host);
+  const totalReportCount = directHits.reduce((sum, record) => sum + record.count, 0)
 
   return (
     <main>
       <h1>{host}</h1>
-      {host} is a confirmed scam by 165. It has been reported {records.reduce((sum, record) => sum + record.count, 0)} times.
+      {
+        totalReportCount === 0 ?
+        `${host} is not reported by 165 yet.` :
+        <>
+          {host} is a confirmed scam by 165. It has been reported {totalReportCount} times.
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>URL</th>
+                <th>Count</th>
+                <th>Start Date</th>
+                <th>End Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {directHits.map((record) => (
+                <tr key={record.id}>
+                  <td><Link href={`/name/${record.name}`}>{record.name}</Link></td>
+                  <td>{record.url}</td>
+                  <td>{record.count}</td>
+                  <td>{record.startDate}</td>
+                  <td>{record.endDate}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      }
+
+      <h2>Similar entries on 165</h2>
       <table>
         <thead>
           <tr>
             <th>Name</th>
             <th>URL</th>
-            <th>Count</th>
-            <th>Start Date</th>
-            <th>End Date</th>
+            <th>Rank</th>
           </tr>
         </thead>
         <tbody>
-          {records.map((record) => (
-            <tr key={record.id}>
-              <td>{record.name}</td>
-              <td>{record.url}</td>
-              <td>{record.count}</td>
-              <td>{record.startDate}</td>
-              <td>{record.endDate}</td>
+          {ftsHits.map((record) => (
+            <tr key={record.rowid}>
+              <td><Link href={`/name/${record.name}`}>{record.name}</Link></td>
+              <td><Link href={`/host/${record.host}`}>{record.url}</Link></td>
+              <td>{record.rank}</td>
             </tr>
           ))}
         </tbody>

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -1,6 +1,8 @@
+import Link from 'next/link';
+
 import { getRequestContext } from '@cloudflare/next-on-pages';
 import { searchSimilar } from '@/lib/fts';
-import Link from 'next/link';
+import Highlighted from '@/components/Highlighted';
 
 export const runtime = 'edge';
 type Record = {
@@ -74,8 +76,16 @@ export default async function Name({params: {name: encodedName}}: {params: {name
         <tbody>
           {ftsHits.map((record) => (
             <tr key={record.rowid}>
-              <td><Link href={`/name/${record.name}`}>{record.name}</Link></td>
-              <td><Link href={`/host/${record.host}`}>{record.url}</Link></td>
+              <td>
+                <Link href={`/name/${record.nameTokens.join('')}`}>
+                  <Highlighted tokens={record.nameTokens} />
+                </Link>
+              </td>
+              <td>
+                <Link href={`/host/${record.host}`}>
+                  <Highlighted tokens={record.urlTokens} />
+                </Link>
+              </td>
               <td>{record.rank}</td>
             </tr>
           ))}

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -1,5 +1,6 @@
-import { trigram } from 'n-gram';
 import { getRequestContext } from '@cloudflare/next-on-pages';
+import { searchSimilar } from '@/lib/fts';
+import Link from 'next/link';
 
 export const runtime = 'edge';
 type Record = {
@@ -20,77 +21,62 @@ async function getRecords(name: string) {
     FROM ScamSiteRecord
     WHERE lower(name) = lower(?)
     ORDER BY endDate DESC
-  `).bind(name).all<Record>();
+  `).bind(name).all<Record>().then(({results}) => results);
 
-  const shouldUseFts = name.length > 3;
-  const grams = trigram(name);
-  const whereClause = shouldUseFts ?
-    `ScamSiteRecordFTS MATCH '${grams.map(g => `"${g.replace('"', '""')}"`).join(' OR ')}'` :
-    `name LIKE ?`;
-  const values = shouldUseFts ? [] : [`%${name}%`];
-  const sql = `
-    SELECT
-      rowid,
-      *,
-      highlight(ScamSiteRecordFTS,0,'{{','}}') AS name,
-      highlight(ScamSiteRecordFTS,1,'{{','}}') AS url
-    FROM ScamSiteRecordFTS
-    WHERE  ${whereClause}
-    ORDER BY rank
-  `;
-
-  console.log(sql, values);
-
-  const ftsHitPromise = db.prepare(sql).bind(...values).all<Pick<Record, 'name' | 'url'> & {rowid: string}>();
-
-  return Promise.all([directHitPromise, ftsHitPromise]);
+  return Promise.all([directHitPromise, searchSimilar(name)]);
 }
 
 export default async function Name({params: {name: encodedName}}: {params: {name: string}}) {
-  const name = decodeURIComponent(encodedName);
-  const [{results: directHits}, {results: ftsHits}] = await getRecords(name);
+  const name = decodeURIComponent(encodedName).trim();
+  const [directHits, ftsHits] = await getRecords(name);
 
   return (
     <main>
       <h1>{name}</h1>
-      The name “{name}” is used by the following know scam sites.
+      {
+        directHits.length === 0 ? `The name ${name} is not reported by 165 yet.` :
+        <>
+          The name “{name}” is used by the following know scam sites.
+          <table>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>URL</th>
+                <th>Count</th>
+                <th>Start Date</th>
+                <th>End Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {directHits.map((record) => (
+                <tr key={record.id}>
+                  <td>{record.name}</td>
+                  <td><Link href={`/host/${record.host}`}>{record.url}</Link></td>
+                  <td>{record.count}</td>
+                  <td>{record.startDate}</td>
+                  <td>{record.endDate}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      }
 
+      <h2>Similar entries on 165</h2>
       <table>
         <thead>
           <tr>
             <th>Name</th>
             <th>URL</th>
-            <th>Count</th>
-            <th>Start Date</th>
-            <th>End Date</th>
-          </tr>
-        </thead>
-        <tbody>
-          {directHits.map((record) => (
-            <tr key={record.id}>
-              <td>{record.name}</td>
-              <td>{record.url}</td>
-              <td>{record.count}</td>
-              <td>{record.startDate}</td>
-              <td>{record.endDate}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-
-      Similar entries
-      <table>
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>URL</th>
+            <th>Rank</th>
           </tr>
         </thead>
         <tbody>
           {ftsHits.map((record) => (
             <tr key={record.rowid}>
-              <td>{record.name}</td>
-              <td>{record.url}</td>
+              <td><Link href={`/name/${record.name}`}>{record.name}</Link></td>
+              <td><Link href={`/host/${record.host}`}>{record.url}</Link></td>
+              <td>{record.rank}</td>
             </tr>
           ))}
         </tbody>

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -70,7 +70,7 @@ export default async function Name({params: {name: encodedName}}: {params: {name
           <tr>
             <th>Name</th>
             <th>URL</th>
-            <th>Rank</th>
+            <th>Reported</th>
           </tr>
         </thead>
         <tbody>
@@ -86,7 +86,7 @@ export default async function Name({params: {name: encodedName}}: {params: {name
                   <Highlighted tokens={record.urlTokens} />
                 </Link>
               </td>
-              <td>{record.rank}</td>
+              <td>{record.count} time(s) during {record.startDate} and {record.endDate}</td>
             </tr>
           ))}
         </tbody>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,7 +43,7 @@ function ScamRecord({ host, names, maxEndDate }: AggregatedRecord) {
       <div className="p-6 border-l-4 border-red-500">
         <h2 className="text-xl font-bold mb-2 text-gray-800">
           <Link
-            href={`/host/${host.toLowerCase()}`}
+            href={`/host/${host}`}
             className="hover:text-red-600 transition-colors duration-300"
           >
             {host}
@@ -57,7 +57,7 @@ function ScamRecord({ host, names, maxEndDate }: AggregatedRecord) {
             <span key={name} className="ml-1">
               {index > 0 && ', '}
               <Link
-                href={`/name/${name.toLowerCase()}`}
+                href={`/name/${name}`}
                 className="text-blue-500 hover:underline"
               >
                 {name}

--- a/components/Highlighted.tsx
+++ b/components/Highlighted.tsx
@@ -1,0 +1,9 @@
+type HighlightedProps = {
+  /** Tokens with odd index (1, 3, 5, ...) should be highlighted */
+  tokens: string[];
+}
+export default function Highlighted({ tokens }: HighlightedProps) {
+  return <>
+    {tokens.map((token, i) => i % 2 === 0 ? token : <mark key={i}>{token}</mark>)}
+  </>;
+}

--- a/db/migrations/0002_create_fts_table.sql
+++ b/db/migrations/0002_create_fts_table.sql
@@ -1,0 +1,8 @@
+-- Migration number: 0002 	 2024-07-25T16:00:25.449Z
+
+CREATE VIRTUAL TABLE IF NOT EXISTS "ScamSiteRecordFTS" USING fts5(
+  name,
+  url,
+  content='ScamSiteRecord',
+  tokenize='trigram'
+);

--- a/lib/fts.ts
+++ b/lib/fts.ts
@@ -9,6 +9,14 @@ type FTSRecord = {
   /** Strings with odd index are matched tokens */
   urlTokens: string[];
   rank: number;
+
+  /** Total number of reports */
+  count: number;
+
+  /** Start date of the first report */
+  startDate: string;
+  /** End date of the last report */
+  endDate: string;
 }
 
 const SEP = ['{{', '}}'];
@@ -29,7 +37,10 @@ export async function searchSimilar(query: string, limit=20): Promise<FTSRecord[
       ranked.name AS name,
       ranked.url AS url,
       ScamSiteRecord.host as host,
-      max(rank) AS rank
+      max(rank) AS rank,
+      sum(count) AS count,
+      min(startDate) AS startDate,
+      max(endDate) AS endDate
     FROM (
       SELECT
         rowid,

--- a/lib/fts.ts
+++ b/lib/fts.ts
@@ -3,18 +3,23 @@ import { getRequestContext } from '@cloudflare/next-on-pages';
 
 type FTSRecord = {
   rowid: number;
-  name: string;
-  host: string;
-  url: string;
+  /** Strings with odd index are matched tokens */
+  nameTokens: string[];
+  host: string[];
+  /** Strings with odd index are matched tokens */
+  urlTokens: string[];
   rank: number;
 }
 
-export async function searchSimilar(query: string, limit=20) {
+const SEP = ['{{', '}}'];
+const SEP_RE = new RegExp(String.raw`${SEP[0]}(.*?)${SEP[1]}`);
+
+export async function searchSimilar(query: string, limit=20): Promise<FTSRecord[]> {
   const db = getRequestContext().env.DB;
   const shouldUseFts = query.length > 2; // ScamSiteRecordFTS is a trigram index
   const whereClause = shouldUseFts ?
     `ScamSiteRecordFTS MATCH '${trigram(query).map(g => `"${g.replaceAll('"', '""')}"`).join(' OR ')}'` :
-    `name LIKE ? OR url LIKE ?`;
+    `(name LIKE ? OR url LIKE ?)`;
   const values = shouldUseFts ? [] : [`%${query}%`, `%${query}%`];
 
   /** Select similar with full-text search, but reject 100% match */
@@ -28,8 +33,8 @@ export async function searchSimilar(query: string, limit=20) {
     FROM (
       SELECT
         rowid,
-        highlight(ScamSiteRecordFTS,0,'{{','}}') AS name,
-        highlight(ScamSiteRecordFTS,1,'{{','}}') AS url,
+        highlight(ScamSiteRecordFTS,0,'${SEP[0]}','${SEP[1]}') AS name,
+        highlight(ScamSiteRecordFTS,1,'${SEP[0]}','${SEP[1]}') AS url,
         rank
       FROM ScamSiteRecordFTS
       WHERE ${whereClause}
@@ -44,10 +49,20 @@ export async function searchSimilar(query: string, limit=20) {
     LIMIT ${limit}
   `;
 
-  // console.info(sql, values);
+  const { results } = await db.prepare(sql).bind(...values, query, query).all<Omit<FTSRecord, 'nameTokens' | 'urlTokens'> & {name: string; url: string}>();
 
-  const { results } = await db.prepare(sql).bind(...values, query, query).all<FTSRecord>();
+  if(!shouldUseFts) {
+    // Modify result name and url to have tokens
+    results.forEach(record => {
+      record.name = record.name.replaceAll(query, `${SEP[0]}$&${SEP[1]}`);
+      record.url = record.url.replaceAll(query, `${SEP[0]}$&${SEP[1]}`);
+    });
+  }
 
-  return results;
+  return results.map(({name, url, ...record}) => ({
+    ...record,
+    nameTokens: name.split(SEP_RE),
+    urlTokens: url.split(SEP_RE),
+  }));
 }
 

--- a/lib/fts.ts
+++ b/lib/fts.ts
@@ -1,0 +1,53 @@
+import { trigram } from 'n-gram';
+import { getRequestContext } from '@cloudflare/next-on-pages';
+
+type FTSRecord = {
+  rowid: number;
+  name: string;
+  host: string;
+  url: string;
+  rank: number;
+}
+
+export async function searchSimilar(query: string, limit=20) {
+  const db = getRequestContext().env.DB;
+  const shouldUseFts = query.length > 2; // ScamSiteRecordFTS is a trigram index
+  const whereClause = shouldUseFts ?
+    `ScamSiteRecordFTS MATCH '${trigram(query).map(g => `"${g.replaceAll('"', '""')}"`).join(' OR ')}'` :
+    `name LIKE ? OR url LIKE ?`;
+  const values = shouldUseFts ? [] : [`%${query}%`, `%${query}%`];
+
+  /** Select similar with full-text search, but reject 100% match */
+  const sql = `
+    SELECT
+      max(rowid) AS rowid,
+      ranked.name AS name,
+      ranked.url AS url,
+      ScamSiteRecord.host as host,
+      max(rank) AS rank
+    FROM (
+      SELECT
+        rowid,
+        highlight(ScamSiteRecordFTS,0,'{{','}}') AS name,
+        highlight(ScamSiteRecordFTS,1,'{{','}}') AS url,
+        rank
+      FROM ScamSiteRecordFTS
+      WHERE ${whereClause}
+        AND lower(name) != lower(?)
+        AND lower(url) != lower(?)
+      ORDER BY rank
+      LIMIT ${limit*2 /* Not sure query it would fail without LIMIT. Enlarge limit for grouping in the next phase */}
+    ) AS ranked
+    LEFT JOIN ScamSiteRecord ON rowid = ScamSiteRecord.id
+    GROUP BY ranked.name, ranked.url
+    ORDER BY rank
+    LIMIT ${limit}
+  `;
+
+  // console.info(sql, values);
+
+  const { results } = await db.prepare(sql).bind(...values, query, query).all<FTSRecord>();
+
+  return results;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@next/third-parties": "^14.2.5",
         "cookie": "^0.6.0",
+        "n-gram": "^2.0.2",
         "next": "14.1.0",
         "pcre-to-regexp": "^1.1.0",
         "react": "^18",
@@ -6974,6 +6975,15 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/n-gram": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@next/third-parties": "^14.2.5",
     "cookie": "^0.6.0",
+    "n-gram": "^2.0.2",
     "next": "14.1.0",
     "pcre-to-regexp": "^1.1.0",
     "react": "^18",

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -9,6 +9,7 @@ import path from "path";
  */
 const NPA_165_SITE_URL = 'https://data.moi.gov.tw/MoiOD/System/DownloadFile.aspx?DATA=3BB8E3CE-8223-43AF-B1AB-5824FA889883';
 const TABLE = 'ScamSiteRecord';
+const FTS_TABLE = 'ScamSiteRecordFTS';
 const SQL_FILE = './tmp/scamSiteRecord.sql';
 
 type NPA165SiteData = /** Fields from data */
@@ -53,6 +54,9 @@ async function main() {
   await writeFile(SQL_FILE, `
     DELETE FROM ${TABLE};
     ${values.map((value) => `INSERT INTO ${TABLE} (name, url, count, startDate, endDate, host) VALUES ${value};`).join('\n')}
+
+    -- Rebuild FTS
+    INSERT INTO ${FTS_TABLE}(${FTS_TABLE}) VALUES('rebuild');
   `.trim());
 }
 


### PR DESCRIPTION
Enables similar entry search on all detail pages

- Add D1 table `ScamSiteRecordsFTS` that indexes scam site info in trigram
- Display similar sites on host and name detail pages. Highlight the searched queries.
- When doing full-text search, we manually split queries into trigrams and connect them with `OR` in order to perform fuzzy match
    - For instance, if query is "長興證券", we also want to match "萬興證券"
    - Since full text search in SQLite only consider documents that match the full phrase, for partial matches we have to break down query by ourselves
    - Ref: https://stackoverflow.com/questions/6543369/include-partial-matches-in-sqlite-fts3-search

Name detail
![圖片](https://github.com/user-attachments/assets/1ba075e3-13ba-46b3-8a92-70cd9b10f2f3)

Host detail
![圖片](https://github.com/user-attachments/assets/a60ffd88-8630-4398-b711-a0cef4937246)
