### PR TITLE
Show and search hosts instead of URLs in related entry table

### DIFF
--- a/app/host/[host]/page.tsx
+++ b/app/host/[host]/page.tsx
@@ -45,7 +45,7 @@ export default async function Host({params: {host}}: {params: {host: string}}) {
         <thead>
           <tr>
             <th>Name</th>
-            <th>URL</th>
+            <th>網域</th>
             <th>Reported</th>
           </tr>
         </thead>
@@ -58,8 +58,8 @@ export default async function Host({params: {host}}: {params: {host: string}}) {
                 </Link>
               </td>
               <td>
-                <Link href={`/host/${record.host}`}>
-                  <Highlighted tokens={record.urlTokens} />
+                <Link href={`/host/${record.hostTokens.join('')}`}>
+                  <Highlighted tokens={record.hostTokens} />
                 </Link>
               </td>
               <td>{record.count} time(s) during {record.startDate} and {record.endDate}</td>

--- a/app/name/[name]/page.tsx
+++ b/app/name/[name]/page.tsx
@@ -45,7 +45,7 @@ export default async function ReportByName({
       <thead>
         <tr>
           <th>Name</th>
-          <th>URL</th>
+          <th>網域</th>
           <th>Reported</th>
         </tr>
       </thead>
@@ -58,8 +58,8 @@ export default async function ReportByName({
               </Link>
             </td>
             <td>
-              <Link href={`/host/${record.host}`}>
-                <Highlighted tokens={record.urlTokens} />
+              <Link href={`/host/${record.hostTokens.join('')}`}>
+                <Highlighted tokens={record.hostTokens} />
               </Link>
             </td>
             <td>{record.count} time(s) during {record.startDate} and {record.endDate}</td>

--- a/app/name/util.ts
+++ b/app/name/util.ts
@@ -15,7 +15,6 @@ type Record = {
 
 /** Get records with site name */
 export const getRecords = cache(async (name: string) => {
-  console.log('[getRecords]', name);
   const db = getRequestContext().env.DB;
   const directHitPromise = db.prepare(`
     SELECT *

--- a/db/migrations/0002_create_fts_table.sql
+++ b/db/migrations/0002_create_fts_table.sql
@@ -2,7 +2,7 @@
 
 CREATE VIRTUAL TABLE IF NOT EXISTS "ScamSiteRecordFTS" USING fts5(
   name,
-  url,
+  host,
   content='ScamSiteRecord',
   tokenize='trigram'
 );

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -32,7 +32,7 @@ CREATE INDEX "ScamSiteRecord_name_idx" ON "ScamSiteRecord"(lower("name"))
 
 CREATE VIRTUAL TABLE "ScamSiteRecordFTS" USING fts5(
   name,
-  url,
+  host,
   content='ScamSiteRecord',
   tokenize='trigram'
 )

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -39,10 +39,11 @@ async function main() {
     return { name: name.trim(), url: url.trim(), count: +count, startDate: startDate.trim(), endDate: endDate.trim(),
       // url can only be in:
       // - some-domain.com
+      // - some-domain.com:port
       // - some-domain.com/some-path
       // - some-domain.com/?some-query
       // - some-domain.com?some-query
-      host: url.match(/^([^?\/]+)/)?.[0] ?? url
+      host: url.match(/^([^?\/:]+)/)?.[0] ?? url
     };
   });
 

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -37,13 +37,17 @@ async function main() {
   ).map((line) => {
     const [name, url, count, startDate, endDate] = line.trim().split(',');
     return { name: name.trim(), url: url.trim(), count: +count, startDate: startDate.trim(), endDate: endDate.trim(),
-      // url can only be in:
-      // - some-domain.com
-      // - some-domain.com:port
-      // - some-domain.com/some-path
-      // - some-domain.com/?some-query
-      // - some-domain.com?some-query
-      // - https://some-domain.com
+
+      /**
+       * Extract host from url. URL in open data may come in these formats:
+       *
+       * - some-domain.com
+       * - some-domain.com:port
+       * - some-domain.com/some-path
+       * - some-domain.com/?some-query
+       * - some-domain.com?some-query
+       * - https://some-domain.com
+       * */
       host: url.match(/^(?:https?:\/\/)?([^?\/:]+)/)?.[1] ?? url
     };
   });

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -43,7 +43,8 @@ async function main() {
       // - some-domain.com/some-path
       // - some-domain.com/?some-query
       // - some-domain.com?some-query
-      host: url.match(/^([^?\/:]+)/)?.[0] ?? url
+      // - https://some-domain.com
+      host: url.match(/^(?:https?:\/\/)?([^?\/:]+)/)?.[1] ?? url
     };
   });
 


### PR DESCRIPTION
- Before this PR, we use host name to perform FTS on URLs. This breaks exact-match rejection logic in FTS and is fixed by indexing hosts instead.
- Handle edge cases (URLs with port number and http scheme) from opendata when extracting host

**BREAKING**: This PR modifies migration script (偷懶不想開新 migration); requires clearing and re-seeding the database. Cloudflare pages preview may not work as expected, as the production DB is not migrated yet.

Before on the left; after on the right.
![image](https://github.com/user-attachments/assets/8ddc361d-ae24-407f-8224-e4b24a58a86e)
![image](https://github.com/user-attachments/assets/81803f1b-0904-4ced-8b73-75a604a7bd6f)
