### PR TITLE
feat: enlarge base font size and apply to body

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,7 +43,7 @@ export default function RootLayout({
         />
       </head>
       <GoogleTagManager gtmId={GTM_ID} />
-      <body>
+      <body className="font-sans text-body">
         <Providers>
           <AppLayout>{children}</AppLayout>
         </Providers>

--- a/components/contents.tsx
+++ b/components/contents.tsx
@@ -30,10 +30,7 @@ export function Paragraph({
 }: React.ComponentPropsWithoutRef<'p'>) {
   return (
     <p
-      className={twMerge(
-        'text-body font-sans my-6 font-light tracking-wide',
-        className
-      )}
+      className={twMerge('my-6 font-light tracking-wide', className)}
       {...props}
     >
       {children}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,9 +15,9 @@ const config: Config = {
       },
       fontSize: {
         // From local styles in Figma
-        body: ['16px', '24px'],
-        body2: ['14px', '20px'],
-        heading: ['18px', '28px'],
+        body: ['18px', '28px'],
+        body2: ['16px', '24px'],
+        heading: ['22px', '28px'],
         display: ['57px', '64px'],
       },
     },


### PR DESCRIPTION
Enlarge basic font size as suggested by @nonumpa in the weekly meeting.

Figma: https://www.figma.com/design/wrgkgbbPtaopquHMRoBXnB/Open165?node-id=0-1

Try out at page build below