### PR TITLE
feat: add update db action

### DIFF
--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -26,11 +26,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote > latest-date.json &&\
-          echo latest-date.json
+          cat latest-date.json
 
       - name: Set latest date
         id: latest-date
-        run: echo "DATA=$(cat latest-date.json | jq '.[0].results.[0].latestDate')" >> $GITHUB_OUTPUT
+        run: echo "DATA=$(cat latest-date.json | jq '.[0].results.[0].latestDate')" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Read latestDate

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          echo "DATA=${wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote | jq '.[0].results.[0].latestDate'}" >> "$GITHUB_OUTPUT"
+          echo "DATA=$(wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote | jq '.[0].results.[0].latestDate')" >> "$GITHUB_OUTPUT"
 
       - name: Read latestDate
         env:

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -25,7 +25,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          echo "DATA=$(wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote | jq '.[0].results.[0].latestDate')" >> "$GITHUB_OUTPUT"
+          echo "DATA=$(npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote | jq '.[0].results.[0].latestDate')" >> "$GITHUB_OUTPUT"
 
       - name: Read latestDate
         env:

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -25,11 +25,13 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote >> latest-date.json
+          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote > latest-date.json &&\
+          echo latest-date.json
 
       - name: Set latest date
         id: latest-date
         run: echo "DATA=$(cat latest-date.json | jq '.[0].results.[0].latestDate')" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Read latestDate
         env:

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Fetch lateset date in DB
         id: latest-date
         env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set latest date
         id: latest-date
-        run: echo "DATA=$(cat tmp/latest-date.json | jq '.[0].results[0].latestDate')" >> "$GITHUB_OUTPUT"
+        run: echo "DATA=$(cat tmp/latest-date.json | jq -r '.[0].results[0].latestDate')" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Generate SQL file

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -1,0 +1,33 @@
+name: Update Database
+
+on:
+  schedule:
+    - cron: '0 12 * * 1-5'  # Run every weekday at 20:00 UTC+8 (12:00 UTC)
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  update-db:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch lateset date in DB
+        id: latest-date
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          echo "DATA=${wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote | jq '.[0].results.[0].latestDate'}" >> "$GITHUB_OUTPUT"
+
+      - name: Read latestDate
+        env:
+          LATEST_DATE: ${{ steps.latest-date.outputs.DATA }}
+        run: echo $LATEST_DATE

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - run: mkdir -p tmp
+
       - name: Fetch lateset date in DB
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -25,9 +25,12 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          echo "DATA=$(npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote | jq '.[0].results.[0].latestDate')" >> "$GITHUB_OUTPUT"
+          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote > latest-date.json
 
-      - name: Read latestDate
-        env:
-          LATEST_DATE: ${{ steps.latest-date.outputs.DATA }}
-        run: echo $LATEST_DATE
+      - name: Read latest-date.json
+        run: cat latest-date.json
+
+      # - name: Read latestDate
+      #   env:
+      #     LATEST_DATE: ${{ steps.latest-date.outputs.DATA }}
+      #   run: echo $LATEST_DATE

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -25,10 +25,10 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote > latest-date.json
+          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote
 
-      - name: Read latest-date.json
-        run: cat latest-date.json
+      # - name: Read latest-date.json
+      #   run: cat latest-date.json
 
       # - name: Read latestDate
       #   env:

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -21,6 +21,8 @@ jobs:
         run: npm ci
 
       - run: mkdir -p tmp
+      - run: curl https://data.moi.gov.tw/MoiOD/System/DownloadFile.aspx?DATA=3BB8E3CE-8223-43AF-B1AB-5824FA889883 -o tmp/scamSiteRecord.csv
+      - run: ls -l tmp
 
       - name: Fetch lateset date in DB
         env:

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -21,8 +21,6 @@ jobs:
         run: npm ci
 
       - run: mkdir -p tmp
-      - run: curl https://data.moi.gov.tw/MoiOD/System/DownloadFile.aspx?DATA=3BB8E3CE-8223-43AF-B1AB-5824FA889883 -o tmp/scamSiteRecord.csv
-      - run: ls -l tmp
 
       - name: Fetch lateset date in DB
         env:

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -21,17 +21,17 @@ jobs:
         run: npm ci
 
       - name: Fetch lateset date in DB
-        id: latest-date
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote
+          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote >> latest-date.json
 
-      # - name: Read latest-date.json
-      #   run: cat latest-date.json
+      - name: Set latest date
+        id: latest-date
+        run: echo "DATA=$(cat latest-date.json | jq '.[0].results.[0].latestDate')" >> $GITHUB_OUTPUT
 
-      # - name: Read latestDate
-      #   env:
-      #     LATEST_DATE: ${{ steps.latest-date.outputs.DATA }}
-      #   run: echo $LATEST_DATE
+      - name: Read latestDate
+        env:
+          LATEST_DATE: ${{ steps.latest-date.outputs.DATA }}
+        run: echo $LATEST_DATE

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -25,12 +25,12 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote > latest-date.json &&\
-          cat latest-date.json
+          npx wrangler d1 execute open165 --command 'SELECT max(endDate) AS latestDate FROM ScamSiteRecord' --json --remote > tmp/latest-date.json &&\
+          cat tmp/latest-date.json
 
       - name: Set latest date
         id: latest-date
-        run: echo "DATA=$(cat latest-date.json | jq '.[0].results[0].latestDate')" >> "$GITHUB_OUTPUT"
+        run: echo "DATA=$(cat tmp/latest-date.json | jq '.[0].results[0].latestDate')" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Read latestDate

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -33,7 +33,16 @@ jobs:
         run: echo "DATA=$(cat tmp/latest-date.json | jq '.[0].results[0].latestDate')" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      - name: Read latestDate
+      - name: Generate SQL file
         env:
           LATEST_DATE: ${{ steps.latest-date.outputs.DATA }}
-        run: echo $LATEST_DATE
+        run: npm run predb:seed
+
+      - name: Update database
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler d1 execute open165 --file tmp/scamSiteRecord.sql --remote
+        # Only update the database if the SQL file is not empty
+        # Ref: https://stackoverflow.com/a/77081661/1582110
+        if: ${{ hashFiles('tmp/scamSiteRecord.sql') != '' }}

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Set latest date
         id: latest-date
-        run: echo "DATA=$(cat latest-date.json | jq '.[0].results.[0].latestDate')" >> "$GITHUB_OUTPUT"
+        run: echo "DATA=$(cat latest-date.json | jq '.[0].results[0].latestDate')" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Read latestDate

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -36,6 +36,8 @@ async function main(
   /** When provided, only generate SQL file when there are new data after `latestDate` */
   latestDate?: string
 ) {
+  console.log('latestDate:', latestDate);
+
   const scamSiteCsv = await (await fetch(NPA_165_SITE_URL)).text();
 
   const rawData: NPA165SiteData[] = scamSiteCsv
@@ -69,7 +71,7 @@ async function main(
       };
     })
     .filter((data) => !latestDate || data.endDate > latestDate);
-
+    
   if (!rawData.length) {
     console.log('No new data found');
     return;

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -69,7 +69,7 @@ async function main(
       };
     })
     .filter((data) => !latestDate || data.endDate > latestDate);
-    
+
   if (!rawData.length) {
     console.log('No new data found');
     return;
@@ -83,11 +83,12 @@ async function main(
       `('${data.name.replaceAll("'", "''")}', '${data.url}', ${data.count}, '${data.startDate}', '${data.endDate}', '${data.host}')`
   );
 
+  const isUpdating = !!latestDate;
   await mkdir(path.parse(SQL_FILE).dir, { recursive: true });
   await writeFile(
     SQL_FILE,
     `
-      DELETE FROM ${TABLE};
+      ${isUpdating ? '' : `DELETE FROM ${TABLE};`}
       ${values.map((value) => `INSERT INTO ${TABLE} (name, url, count, startDate, endDate, host) VALUES ${value};`).join('\n')}
 
       -- Rebuild FTS

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -7,8 +7,12 @@ import path from 'path';
  * 165反詐騙諮詢專線_假投資(博弈)網站
  * https://data.gov.tw/dataset/160055
  */
-const NPA_165_SITE_URL =
-  'https://data.moi.gov.tw/MoiOD/System/DownloadFile.aspx?DATA=3BB8E3CE-8223-43AF-B1AB-5824FA889883';
+const NPA_165_SITE_URL = process.env.CI
+  ? // Ronny Wang's mirror to bypass IP region block
+    'https://raw.githubusercontent.com/g0v-data/165-data/main/gamble.csv'
+  : // Official data source
+    'https://data.moi.gov.tw/MoiOD/System/DownloadFile.aspx?DATA=3BB8E3CE-8223-43AF-B1AB-5824FA889883';
+
 const TABLE = 'ScamSiteRecord';
 const FTS_TABLE = 'ScamSiteRecordFTS';
 const SQL_FILE = './tmp/scamSiteRecord.sql';

--- a/scripts/syncSiteRecord.ts
+++ b/scripts/syncSiteRecord.ts
@@ -36,8 +36,6 @@ async function main(
   /** When provided, only generate SQL file when there are new data after `latestDate` */
   latestDate?: string
 ) {
-  console.log('latestDate:', latestDate);
-
   const scamSiteCsv = await (await fetch(NPA_165_SITE_URL)).text();
 
   const rawData: NPA165SiteData[] = scamSiteCsv


### PR DESCRIPTION
Add a Github workflow that updates the remote database on 8pm every weekday.

Latest data now on https://165.g0v.tw/

Successful run that updates stuff: https://github.com/cofacts/open165/actions/runs/10590792684
![image](https://github.com/user-attachments/assets/54c15599-5c87-42b2-bd2e-a0dbb15d72e0)

Skips update when no new data:
https://github.com/cofacts/open165/actions/runs/10590884562/job/29347351687
![image](https://github.com/user-attachments/assets/c4f1ba8e-b839-478e-b310-ac121d7e1cfb)
