### PR TITLE
Sync announcements in 165 to DB

### DIFF
--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -44,7 +44,8 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: npx wrangler d1 execute open165 --file tmp/scamSiteRecord.sql --remote
-        # Only update the database if the SQL file is not empty
+        run: npx wrangler d1 execute open165 --file tmp/scamSiteRecord.sql --remote && \
+             npx wrangler d1 execute open165 --file tmp/scamSiteAnnouncement.sql --remote
+        # Only update the database if there are new scam site records
         # Ref: https://stackoverflow.com/a/77081661/1582110
         if: ${{ hashFiles('tmp/scamSiteRecord.sql') != '' }}

--- a/db/migrations/0003_create_scam_site_announcement_table.sql
+++ b/db/migrations/0003_create_scam_site_announcement_table.sql
@@ -4,6 +4,7 @@ CREATE TABLE "ScamSiteAnnouncement"
     -- 165反詐騙官網「民眾通報假投資(博弈)詐騙網站」系列公告
 (
     "id" INTEGER NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL, -- Announcement title
     "endDate" TEXT NOT NULL, -- Announcement range end in "YYYY/MM/DD", maps to "endDate" in "ScamSiteRecord"
     "publishDate" TEXT NOT NULL -- Announcement publish date in "YYYY-MM-DDThh:mm:ss+08:00"
 );

--- a/db/migrations/0003_create_scam_site_announcement_table.sql
+++ b/db/migrations/0003_create_scam_site_announcement_table.sql
@@ -3,7 +3,7 @@
 CREATE TABLE "ScamSiteAnnouncement"
     -- 165反詐騙官網「民眾通報假投資(博弈)詐騙網站」系列公告
 (
-    "id" INTEGER NOT NULL PRIMARY KEY,
+    "id" INTEGER NOT NULL PRIMARY KEY, -- Article ID on 165 反詐騙官網 （https://165.npa.gov.tw/article/9/<id>）
     "title" TEXT NOT NULL, -- Announcement title
     "endDate" TEXT NOT NULL, -- Announcement range end in "YYYY/MM/DD", maps to "endDate" in "ScamSiteRecord"
     "publishDate" TEXT NOT NULL -- Announcement publish date in "YYYY-MM-DDThh:mm:ss+08:00"

--- a/db/migrations/0003_create_scam_site_announcement_table.sql
+++ b/db/migrations/0003_create_scam_site_announcement_table.sql
@@ -1,0 +1,13 @@
+-- Migration number: 0003 	 2024-09-17T17:39:43.162Z
+
+CREATE TABLE "ScamSiteAnnouncement"
+    -- 165反詐騙官網「民眾通報假投資(博弈)詐騙網站」系列公告
+(
+    "id" INTEGER NOT NULL PRIMARY KEY,
+    "endDate" TEXT NOT NULL, -- Announcement range end in "YYYY/MM/DD", maps to "endDate" in "ScamSiteRecord"
+    "publishDate" TEXT NOT NULL -- Announcement publish date in "YYYY-MM-DDThh:mm:ss+08:00"
+);
+
+-- CreateIndex
+CREATE INDEX "ScamSiteAnnouncement_endDate_idx" ON "ScamSiteAnnouncement"("endDate");
+CREATE INDEX "ScamSiteRecord_endDate_idx" ON "ScamSiteRecord"("endDate");

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -44,3 +44,15 @@ CREATE TABLE 'ScamSiteRecordFTS_idx'(segid, term, pgno, PRIMARY KEY(segid, term)
 CREATE TABLE 'ScamSiteRecordFTS_docsize'(id INTEGER PRIMARY KEY, sz BLOB)
 
 CREATE TABLE 'ScamSiteRecordFTS_config'(k PRIMARY KEY, v) WITHOUT ROWID
+
+CREATE TABLE "ScamSiteAnnouncement"
+    -- 165反詐騙官網「民眾通報假投資(博弈)詐騙網站」系列公告
+(
+    "id" INTEGER NOT NULL PRIMARY KEY,
+    "endDate" TEXT NOT NULL, -- Announcement range end in "YYYY/MM/DD", maps to "endDate" in "ScamSiteRecord"
+    "publishDate" TEXT NOT NULL -- Announcement publish date in "YYYY-MM-DDThh:mm:ss+08:00"
+)
+
+CREATE INDEX "ScamSiteAnnouncement_endDate_idx" ON "ScamSiteAnnouncement"("endDate")
+
+CREATE INDEX "ScamSiteRecord_endDate_idx" ON "ScamSiteRecord"("endDate")

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -49,6 +49,7 @@ CREATE TABLE "ScamSiteAnnouncement"
     -- 165反詐騙官網「民眾通報假投資(博弈)詐騙網站」系列公告
 (
     "id" INTEGER NOT NULL PRIMARY KEY,
+    "title" TEXT NOT NULL, -- Announcement title
     "endDate" TEXT NOT NULL, -- Announcement range end in "YYYY/MM/DD", maps to "endDate" in "ScamSiteRecord"
     "publishDate" TEXT NOT NULL -- Announcement publish date in "YYYY-MM-DDThh:mm:ss+08:00"
 )

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "gen:env": "wrangler types --env-interface CloudflareEnv env.d.ts",
     "gen:migration": "wrangler d1 migrations create open165",
     "gen:schema": "wrangler d1 execute open165 --json --command 'SELECT sql FROM sqlite_master' | tsx ./scripts/genSchema.ts",
-    "predb:seed": "tsx ./scripts/syncSiteRecord.ts",
-    "db:seed": "wrangler d1 execute open165 --file tmp/scamSiteRecord.sql",
+    "predb:seed": "tsx ./scripts/syncSiteRecord.ts && tsx ./scripts/syncSiteAnnouncements.ts",
+    "db:seed": "wrangler d1 execute open165 --file tmp/scamSiteRecord.sql && wrangler d1 execute open165 --file tmp/scamSiteAnnouncement.sql",
     "db:migrate": "wrangler d1 migrations apply open165"
   },
   "dependencies": {

--- a/scripts/syncSiteAnnouncements.ts
+++ b/scripts/syncSiteAnnouncements.ts
@@ -1,0 +1,59 @@
+/** Sync ScamSiteAnnouncement from 165 website to DB by generating the SQL to execute */
+
+import { mkdir, writeFile } from 'fs/promises';
+import path from 'path';
+
+/**
+ * 165反詐騙官網使用之 API
+ */
+const NPA_165_ANNOUNCEMENT_API = 'https://165.npa.gov.tw/api/article/list/9';
+
+// {"category":null,"id":1569,"title":"113/8/29-113/9/4民眾通報假投資(博弈)詐騙網站 【網友不會幫你賺錢、請勿聽信網友投資】","content":null,"publishDate":"2024-09-05T20:32:00+08:00","topFlag":null,"lastUpdTm":null,"oldId":null,"hasFile":null,"promoFile":null,"fileName":null}
+const TABLE = 'ScamSiteAnnouncement';
+const SQL_FILE = './tmp/scamSiteAnnouncement.sql';
+const ANNOUCNEMENT_REGEX = /通報假投資/;
+
+type NPA165Announcement = {
+  id: string;
+  title: string;
+  publishDate: string;
+};
+
+/**
+ * Possible title formats and their respective expected output
+ * - 165反詐騙諮詢專線公布108/12/30-109/01/05民眾通報高風險賣場(平臺) --> 2020/01/05
+ * - 公布108/12/11-12/17民眾通報假投資博奕網站(投資網站) --> 2019/12/17
+ * - 公布2/6-2/12民眾通報假投資(博奕)詐騙網站 --> 2020/02/12 (year comes from publishDate)
+ * @param title
+ * @returns
+ */
+function getEndDate(title: string) {
+  const matches = title.match(/-(\d+)\/(\d+)\/(\d+)/);
+  if (!matches) throw new Error(`Cannot extract end date from "${title}"`);
+  const [, rocYear, month, date] = matches;
+  return `${+rocYear + 1911}/${month.padStart(2, '0')}/${date.padStart(2, '0')}`;
+}
+
+async function main() {
+  const announcements: NPA165Announcement[] = await (
+    await fetch(NPA_165_ANNOUNCEMENT_API)
+  ).json();
+  await mkdir(path.parse(SQL_FILE).dir, { recursive: true });
+  const values = announcements
+    .filter(({ title }) => title.match(ANNOUCNEMENT_REGEX))
+    .map(
+      ({ id, title, publishDate }) =>
+        `(${id}, '${title.replaceAll("'", "''")}', '${getEndDate(title)}', '${publishDate}')`
+    );
+
+  await writeFile(
+    SQL_FILE,
+    `
+      DELETE FROM ${TABLE};
+      ${values.map((value) => `INSERT INTO ${TABLE} (id, title, endDate, publishDate) VALUES ${value};`).join('\n')}
+
+    `.trim()
+  );
+}
+
+main().catch(console.error);


### PR DESCRIPTION
This PR adds the 165 網站公告 ID to DB, with data source from 165 website's API (not in open data though)

The `id` maps to URL `https://165.npa.gov.tw/article/9/:id`
![image](https://github.com/user-attachments/assets/4ed6d91b-5546-4b21-9f98-160dc35fcc41)

We will match the field `endDate` with the `endDate` in `ScamSiteRecord` table.

This data will be used here, attaching link to official 165 announcement
![image](https://github.com/user-attachments/assets/725477b8-60b8-46da-8d6c-5bdac6ec9387)
