### PR TITLE
Add gha-creds-*.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 # wrangler files
 .wrangler
 .dev.vars
+
+# Prevent google-github-actions/auth credentials being committed to git by accident
+gha-creds-*.json


### PR DESCRIPTION
## Summary
- Add `gha-creds-*.json` to .gitignore to prevent google-github-actions/auth credentials being committed to git by accident

## Test plan
- [x] Verify .gitignore entry is properly formatted
- [x] Confirm the pattern matches the expected credential file format

🤖 Generated with [Claude Code](https://claude.ai/code)